### PR TITLE
Command-line interface and processing multiple files

### DIFF
--- a/docgen/src/cli.py
+++ b/docgen/src/cli.py
@@ -36,6 +36,7 @@ def parse_cli_args():
             help="path to the json file that the tool will generate")
     parser.add_argument("-t", "--types", nargs="+", default=["all"], choices=doc_types,
             help="list of documentation types that will be added to output")
+    parser.add_argument("--plot-graph", action="store_true", help="create a plot of generated code_graph")
     
     args = vars(parser.parse_args())
     args["types"] = validate_doc_types(args["types"])

--- a/docgen/src/cli.py
+++ b/docgen/src/cli.py
@@ -1,0 +1,43 @@
+
+from argparse import ArgumentParser
+
+def get_supported_types():
+    "Gets list of recognized documentation types"
+    return ["function", "class", "file", "repo", "code-graph"]
+
+def validate_doc_types(types):
+    "Converts requested documentation types to a set, and changes the types based on the dependencies between types"
+    if "all" in types:
+        return set(get_supported_types())
+    result = set(types)
+    
+    # Repo overview requires file overviews
+    if "repo" in result: 
+        result.add("file")
+
+    # File overview and code graph need functions, classes or both
+    if "file" in result or"code-graph" in result:
+        if "class" not in result and "function" not in result:
+            result.add("class")
+            result.add("function")
+    return result
+    
+
+def parse_cli_args():
+    "Parses command-line arguments and returns them as a dictionary"
+    doc_types = ["all"] + get_supported_types()
+    example = "example:\ndocgen . -o docs/generated.json -t function class"
+    parser = ArgumentParser(prog="Docgen", description="Generates repository documentation", epilog=example)
+
+    parser.add_argument("repo_path", help="path to repository or file that will be documented")
+    parser.add_argument("-m", "--model", default="llama-3.2-90b-vision-preview",
+            help="used groq model ID (https://console.groq.com/docs/models)")
+    parser.add_argument("-o", "--output", default="output.json",
+            help="path to the json file that the tool will generate")
+    parser.add_argument("-t", "--types", nargs="+", default=["all"], choices=doc_types,
+            help="list of documentation types that will be added to output")
+    
+    args = vars(parser.parse_args())
+    args["types"] = validate_doc_types(args["types"])
+    return args
+

--- a/docgen/src/code_documentation.py
+++ b/docgen/src/code_documentation.py
@@ -1,3 +1,4 @@
+from similarity_graph import graph_to_dict
 
 class FileDoc():
     """Contains the documentation for a single source code file"""
@@ -26,4 +27,19 @@ class FileDoc():
             'overview': self.overview,
             'functions': self.functions,
             'classes': self.classes,
+        }
+
+class RepoDoc():
+    "Contains the documentation for the whole repo"
+
+    def __init__(self, **kwargs):
+        self.overview = kwargs.get("overview", "") # String
+        self.files = kwargs.get("files", []) # List[FileDoc]
+        self.code_graph = kwargs.get("code_graph", None) # networkx.Graph
+
+    def as_dict(self):
+        return {
+            "overview": self.overview,
+            "files": [file.as_dict() for file in self.files],
+            "code_graph": graph_to_dict(self.code_graph),
         }

--- a/docgen/src/main.py
+++ b/docgen/src/main.py
@@ -5,7 +5,7 @@ from code_documentation import RepoDoc
 from overview import generate_repository_overview
 from util import save_to_json, load_json, list_files_if
 from cli import parse_cli_args
-from similarity_graph import create_code_graph
+from similarity_graph import create_code_graph, plot_graph
 from langchain_groq import ChatGroq
 from langchain.globals import set_debug
 from dotenv import load_dotenv
@@ -46,5 +46,8 @@ if __name__ == "__main__":
     save_to_json(repo_doc.as_dict(), cli_args["output"])
     print_stats(repo_doc)
     print(f"\nFinished and saved to {cli_args['output']}")
+    if cli_args["plot_graph"]:
+       plot_graph(repo_doc.code_graph) 
+
 
 

--- a/docgen/src/main.py
+++ b/docgen/src/main.py
@@ -1,51 +1,50 @@
 import sys
 import os
-from code_description import describe_file_funcs, describe_file_classes, describe_file, describe_file_
+from code_description import describe_file_funcs, describe_file_classes, describe_file
+from code_documentation import RepoDoc
 from overview import generate_repository_overview
-from util import save_to_json, load_json
+from util import save_to_json, load_json, list_files_if
+from cli import parse_cli_args
+from similarity_graph import create_code_graph
 from langchain_groq import ChatGroq
 from langchain.globals import set_debug
 from dotenv import load_dotenv
 
+def describe_repo(llm, cli_args):
+    code_files = list_files_if(cli_args["repo_path"], lambda name: name.endswith(".py"))
 
-def print_stats(filedoc):
+    code_docs = [describe_file(llm, file, 
+        include_funcs="function" in cli_args["types"],
+        include_classes="class" in cli_args["types"],
+        include_overview="file" in cli_args["types"]
+    ) for file in code_files]
+    
+    result = {"files": code_docs}
+    if "repo" in cli_args["types"]:
+        result["overview"] = generate_repository_overview(llm, [doc.as_dict() for doc in code_docs])
+    if "code-graph" in cli_args["types"]:
+        result["code_graph"] = create_code_graph(code_docs)
+    return RepoDoc(**result)
+
+def print_stats(repo_doc):
+    def print_sum(text, func):
+        print(text, sum([func(file) for file in repo_doc.files]))
     print("# Stats")
-    print("classes:", len(filedoc.classes))
-    print("  methods:", len(filedoc.get_methods()))
-    print("    params:", filedoc.count_method_params())
-    print("functions:", len(filedoc.functions))
-    print("  params:", filedoc.count_function_params())
+    print("files:", len(repo_doc.files))
+    print_sum("classes:", lambda filedoc : len(filedoc.classes))
+    print_sum("  methods:", lambda filedoc : len(filedoc.get_methods()))
+    print_sum("    params:", lambda filedoc : filedoc.count_method_params())
+    print_sum("functions:", lambda filedoc : len(filedoc.functions))
+    print_sum("  params:", lambda filedoc : filedoc.count_function_params())
 
-
-load_dotenv()
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        exit("USAGE: python3 main.py <python file>")
+    load_dotenv()
+    cli_args = parse_cli_args()
+    llm = ChatGroq(model=cli_args["model"], api_key=os.getenv("API_KEY"))
+    repo_doc = describe_repo(llm, cli_args)
+    save_to_json(repo_doc.as_dict(), cli_args["output"])
+    print_stats(repo_doc)
+    print(f"\nFinished and saved to {cli_args['output']}")
 
-    #To test repo overview: python3 main.py repo     (note: expects output.json to exist)
-    if "repo" in sys.argv:
-        llm = ChatGroq(
-            model="llama3-groq-8b-8192-tool-use-preview",
-            api_key=os.getenv("API_KEY")
-        )
-        file = load_json("output.json")
-        if any("overview" in file_data for file_data in file):
-            summary = generate_repository_overview(llm, file)
-            print(
-                f"\nGenerated the following repo summary based on the overview(s):\n{summary}")
-            exit()
 
-    # set_debug(True)
-    llm = ChatGroq(
-        model="llama3-groq-8b-8192-tool-use-preview",
-        api_key=os.getenv("API_KEY")
-    )
-
-    # for now: describe_file_funcs, describe_file_classes or describe_file
-    result = describe_file_(llm, sys.argv[1])
-
-    filename = "output.json"
-    save_to_json([result.as_dict()], filename)
-    print_stats(result)
-    print(f"\nFinished and saved to {filename}")

--- a/docgen/src/similarity_graph.py
+++ b/docgen/src/similarity_graph.py
@@ -47,6 +47,8 @@ def plot_graph(graph):
 
     
 def graph_to_dict(graph):
+    if not graph:
+        return {}
     edges = {}
     for n, nbrs in graph.adj.items():
         neighbours = []

--- a/docgen/src/similarity_graph.py
+++ b/docgen/src/similarity_graph.py
@@ -5,6 +5,9 @@ from util import save_to_json
 
 def get_document_distances(doc_ids, docs, max_result_count):
     """Returns a dictionary where each doc_id has a list of (other_id, distance_from_other_id) tuples"""
+    if len(doc_ids) == 0 or len(docs) == 0:
+        return {}
+
     chroma_client = chromadb.Client()
     db = chroma_client.create_collection(name="code-descriptions")
     db.add(documents=docs, ids=doc_ids)
@@ -42,28 +45,23 @@ def plot_graph(graph):
     nx.draw(graph, pos=pos, with_labels=True)
     plt.show()
 
-
-def save_graph_json(graph, filepath):
+    
+def graph_to_dict(graph):
     edges = {}
     for n, nbrs in graph.adj.items():
         neighbours = []
         for nbr, eattr in nbrs.items():
             neighbours.append({"to": nbr, "dist": eattr["weight"]})
         edges[n] = neighbours
-    json = {"nodes" : list(graph.nodes), "edges" : edges}
-    save_to_json(json, filepath)
+    return {"nodes" : list(graph.nodes), "edges" : edges}
 
 
-if __name__ == "__main__": # For testing
-    from util import load_json
-
-    test_input = load_json("output.json")
-    test_input = test_input["classes"] + test_input["functions"]
-    keys = [json["name"] for json in test_input]
-    values = [json["description"] for json in test_input]
-
+def create_code_graph(filedocs):
+    funcs_and_classes = []
+    for doc in filedocs:
+        funcs_and_classes.extend(doc.classes + doc.functions)
+    keys = [code["name"] for code in funcs_and_classes]
+    values = [code["description"] for code in funcs_and_classes]
     distances = get_document_distances(keys, values, 50)
-    g = build_similarity_graph(distances, 0.8)
-    save_graph_json(g, "graph.json")
-    print("saved graph as graph.json")
-    plot_graph(g)
+    return build_similarity_graph(distances, 0.8)
+

--- a/docgen/src/util.py
+++ b/docgen/src/util.py
@@ -1,5 +1,5 @@
 import json
-
+import os
 
 def save_to_json(data, filename):
     with open(filename, 'w') as json_file:
@@ -8,3 +8,21 @@ def save_to_json(data, filename):
 def load_json(filename):
     with open(filename) as json_file:
         return json.load(json_file)
+
+def list_files_if(base_path, condition_func):
+    "Returns a list of filenames within base_path for which condition_func returns True. base_path can also be a single file."
+    if os.path.isfile(base_path):
+        if condition_func(base_path):
+            return [base_path]
+        return []
+    result = []
+    def recurse(directory):
+        for item in os.listdir(directory):
+            item_path = os.path.join(directory, item)
+            if os.path.isdir(item_path):
+                recurse(item_path)
+            elif condition_func(item):
+                result.append(item_path)
+    recurse(base_path)
+    return result
+


### PR DESCRIPTION
I created a command-line interface that allows the user to select which documentation type(s) they want. It also lets the user specify the output.json path and the used llm model id. All options except repo_path are optional, so the tool can still be used the same way as before. The repo_path can either be a path to a single file or a path to a directory in which case all python files within that directory are considered.

Here's the help prompt printed by the program:
```
usage: Docgen [-h] [-m MODEL] [-o OUTPUT] [-t {all,function,class,file,repo,code-graph} [{all,function,class,file,repo,code-graph} ...]] [--plot-graph]
              repo_path

Generates repository documentation

positional arguments:
  repo_path             path to repository or file that will be documented

options:
  -h, --help            show this help message and exit
  -m MODEL, --model MODEL
                        used groq model ID (https://console.groq.com/docs/models)
  -o OUTPUT, --output OUTPUT
                        path to the json file that the tool will generate
  -t {all,function,class,file,repo,code-graph} [{all,function,class,file,repo,code-graph} ...], --types {all,function,class,file,repo,code-graph} [{all,function,class,file,repo,code-graph} ...]
                        list of documentation types that will be added to output
  --plot-graph          create a plot of generated code_graph

example: docgen . -o docs/generated.json -t function class

```
