### PR TITLE
document python file imports

### DIFF
--- a/docgen/src/cli.py
+++ b/docgen/src/cli.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 
 def get_supported_types():
     "Gets list of recognized documentation types"
-    return ["function", "class", "file", "repo", "code-graph"]
+    return ["function", "class", "file", "repo", "code-graph", "imports"]
 
 def validate_doc_types(types):
     "Converts requested documentation types to a set, and changes the types based on the dependencies between types"

--- a/docgen/src/code_documentation.py
+++ b/docgen/src/code_documentation.py
@@ -8,6 +8,7 @@ class FileDoc():
         self.overview = kwargs.get("overview", "") # String
         self.functions = kwargs.get("funcs", []) # List[FunctionDescription]
         self.classes = kwargs.get("classes", []) # List[ClassDescription]
+        self.imports = kwargs.get("imports", []) # List[String]
 
     def get_methods(self):
         return [m for c in self.classes if "methods" in c for m in c.get("methods", [])]
@@ -27,6 +28,7 @@ class FileDoc():
             'overview': self.overview,
             'functions': self.functions,
             'classes': self.classes,
+            'imports': self.imports,
         }
 
 class RepoDoc():

--- a/docgen/src/main.py
+++ b/docgen/src/main.py
@@ -15,7 +15,8 @@ def describe_repo(llm, cli_args):
     code_docs = [describe_file(llm, file, 
         include_funcs="function" in cli_args["types"],
         include_classes="class" in cli_args["types"],
-        include_overview="file" in cli_args["types"]
+        include_overview="file" in cli_args["types"],
+        include_imports="imports" in cli_args["types"]
     ) for file in code_files]
     
     result = {"files": code_docs}


### PR DESCRIPTION
This adds a new documentation type "imports" that adds a list of imported python files to the output. Currently only imported files within the repo are considered. The imports are formatted as relative paths that correspond with the names of files in the output json.