### PR TITLE
Some basic exception handling with fallbacks

### DIFF
--- a/docgen/src/code_description.py
+++ b/docgen/src/code_description.py
@@ -4,7 +4,6 @@ from parsing import parse_code_file, get_definitions, parse_python_imports
 from code_documentation import FileDoc
 from overview import generate_file_overview
 from fewshots import class_struct_example
-from langchain_core.exceptions import LangChainException
 import os
 
 class Param(TypedDict):


### PR DESCRIPTION
This changes the class and function description generation so that if llm.invoke raises an exception, the input is reprocessed with a simpler prompt that doesn't require structured output. This should allow any groq models to be used to generate documentation without crashing on tool use errors.