### PR TITLE
Add: readme link to demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CodeScape
 
+Demo app is running at [Render](https://codescape.onrender.com/)
+
 ## Setup Instructions
 
 1. **Create a `.env` file** in src directory.


### PR DESCRIPTION
Adds readme link to the demo app which is running at https://codescape.onrender.com/

The demo app is running on the demo_examples branch. I had to do all kinds of weird workarounds because I did not realise that the static website would behave differently (initially, it only displayed a white page). As a result, the branch contains a lot of unnecessary and illogical code. It’s best to keep the branch separate and use it solely for demoing purposes (at least for now :D).